### PR TITLE
Add overview content for navigation categories

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,10 +1,11 @@
 # 📚 Wiki Navigation
 
-* [🏠 Home](README.md)
-* Getting Started
+* [🏠 Home](home.md)
+* [🚀 Getting Started](getting-started.md)
   * [📥 How to Join](getting-started/how-to-join.md)
   * [🔧 Basic Commands](getting-started/basic-commands.md)
-* Features
+* [✨ Features](features.md)
   * [🏠 Claims](features/claims.md)
   * [🪦 Graves](features/graves.md)
   * [☠️ Death & Respawn](features/death-and-respawn.md)
+  * [📊 Stats](features/stats.md)

--- a/features.md
+++ b/features.md
@@ -1,0 +1,17 @@
+# ✨ Features Overview
+
+Welcome to the **Gr1zzlyMC** feature hub! Each system below has its own detailed guide, but this page gives you a snapshot so you can decide where to dive in next.
+
+## 🏠 Claims & Protection
+Secure your builds, lock containers, and keep griefers out. Learn how to set up land claims, manage trusted players, and keep your island safe in the full [Claims guide](features/claims.md).
+
+## 🪦 Graves
+Never lose your progress to an unlucky fall again. The [Graves system](features/graves.md) stores your inventory and experience when you die so you can recover everything when you return.
+
+## ☠️ Death & Respawn
+Understand what happens when you respawn, how to return to your island quickly, and what penalties (if any) you should expect. Read the full [Death & Respawn breakdown](features/death-and-respawn.md).
+
+## 📊 Player Stats *(coming soon)*
+Track your island milestones and personal achievements. The [Stats page](features/stats.md) will cover leaderboards, personal records, and more as the system rolls out.
+
+> 💡 Looking for something specific? Use the navigation on the left to jump directly into the detailed guides.

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,0 +1,14 @@
+# 🚀 Getting Started Overview
+
+New to **Gr1zzlyMC**? Start here for a guided launch into the server. This overview highlights the essential steps every newcomer should take before exploring the deeper guides.
+
+## 1. Join the Server
+Whether you're on Java, Bedrock, mobile, or console, we support cross-play. Follow the platform-specific instructions in [How to Join](getting-started/how-to-join.md) to connect for the first time.
+
+## 2. Learn the Basics
+Once you're online, get familiar with the commands that make life easier. The [Basic Commands cheat sheet](getting-started/basic-commands.md) covers teleportation, claiming, economy shortcuts, and more.
+
+## 3. Claim Your Space *(coming soon)*
+We're preparing a step-by-step island setup guide so you know exactly what to do after you spawn. Check back soon for the full walkthrough, including starter kits and protection tips.
+
+> 🎯 Ready for more? Explore the feature guides for in-depth mechanics, events, and advanced systems.


### PR DESCRIPTION
## Summary
- create dedicated overview pages for the Getting Started and Features sections so the navigation items open to real content
- update the table of contents to point Home to the correct file and list the new overview pages alongside their sub-guides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cb7c9a2483329aa1e0c314c65a67