### PR TITLE
Fix GitBook links for home and command docs

### DIFF
--- a/getting-started/basic-commands.md
+++ b/getting-started/basic-commands.md
@@ -61,7 +61,7 @@ All players have access to these by default, and they’ll help you navigate, bu
 
 ---
 
-💡 **Tip:** New commands unlock as you rank up or gain permissions — check out the [Ranks & Permissions](../features/ranks.md) page for more details.
+💡 **Tip:** New commands unlock as you rank up or gain permissions — check out the **Ranks & Permissions** guide (coming soon) for more details.
 
 ---
 

--- a/home.md
+++ b/home.md
@@ -36,8 +36,8 @@
 ---
 
 ## ⚙️ Core Features
-- 🪦 **[Graves](graves.md):** Your items & XP are safe on death.
-- ☠️ **[Death & Respawn](death-and-respawn.md):** Respawn on your island (or hub), no coin loss.
+- 🪦 **[Graves](features/graves.md):** Your items & XP are safe on death.
+- ☠️ **[Death & Respawn](features/death-and-respawn.md):** Respawn on your island (or hub), no coin loss.
 - 🏠 Claims & Protection — Lock down your builds.
 - 🪙 Economy — Earn, trade, and spend across the server.
 - 🏆 Ranks — Progression with perks.
@@ -46,7 +46,7 @@
 
 ## 📚 New Player Essentials
 - 📖 **[Getting Started](getting-started.md)**
-- 🔧 **[Basic Commands](commands.md)**
+- 🔧 **[Basic Commands](getting-started/basic-commands.md)**
 - 🏝️ **Islands Guide** *(coming soon)*
 
 ---


### PR DESCRIPTION
## Summary
- update home page feature and essentials links to point at the correct GitBook pages
- replace the missing ranks link with a coming-soon note to avoid broken redirects

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9e2e5061c8332baf1908546db7984