### PR TITLE
Add patch notes section to wiki sidebar

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,3 +10,5 @@
   * [☠️ Death & Respawn](features/death-and-respawn.md)
   * [📊 Skills & Stats](features/skills.md)
   * [📊 Stats](features/stats.md)
+* 🧩 Extras
+  * [📝 Patch Notes](extras/patch-notes.md)

--- a/extras/patch-notes.md
+++ b/extras/patch-notes.md
@@ -1,0 +1,6 @@
+# 📝 Patch Notes
+
+## 1.00.01 — Bedrock Support Update
+- Added support for the latest Bedrock version, ensuring players can connect without compatibility issues.
+
+Stay tuned for future updates and improvements!


### PR DESCRIPTION
## Summary
- add a new Extras category to the sidebar navigation
- add a patch notes page with the 1.00.01 Bedrock support update entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3d6ae708833299168a11fe002839