### PR TITLE
Add island upgrades guide

### DIFF
--- a/features.md
+++ b/features.md
@@ -8,6 +8,9 @@ Secure your builds, lock containers, and keep griefers out. Learn how to set up 
 ## 🪦 Graves
 Never lose your progress to an unlucky fall again. The [Graves system](features/graves.md) stores your inventory and experience when you die so you can recover everything when you return.
 
+## 🏝️ Island Upgrades
+Invest money into permanent island buffs. The [Island Upgrades guide](features/island-upgrades.md) lists every upgrade tier, cost, and effect so you can plan your progression.
+
 ## ☠️ Death & Respawn
 Understand what happens when you respawn, how to return to your island quickly, and what penalties (if any) you should expect. Read the full [Death & Respawn breakdown](features/death-and-respawn.md).
 

--- a/features/island-upgrades.md
+++ b/features/island-upgrades.md
@@ -1,0 +1,110 @@
+# 🏝️ Island Upgrades Guide
+
+Upgrade your island to unlock powerful boosts. Use `/is upgrades` to open the menu and spend money to improve your island. Each upgrade has multiple levels — higher levels give stronger effects.
+
+---
+
+## 📦 Hopper Limit
+
+| Level | Limit | Cost |
+|-------|-------|------|
+| 1 | 8 | $1,000,000 |
+| 2 | 16 | $3,000,000 |
+| 3 | 32 | $9,000,000 |
+| 4 | 64 | Max |
+
+**Effect:** Increases how many hoppers can be placed on your island.
+
+---
+
+## 🌾 Crop Growth Speed
+
+| Level | Growth Speed | Cost |
+|-------|---------------|------|
+| 1 | 2× | $100,000 |
+| 2 | 3× | $500,000 |
+| 3 | 4× | $1,000,000 |
+| 4 | Max | — |
+
+**Effect:** Crops grow faster on your island.
+
+---
+
+## 🐷 Spawner Rates
+
+| Level | Speed | Cost |
+|-------|-------|------|
+| 1 | 2× | $500,000 |
+| 2 | 3× | $1,000,000 |
+| 3 | 4× | $2,500,000 |
+| 4 | Max | — |
+
+**Effect:** Mobs spawn faster from spawners.
+
+---
+
+## 💎 Mob Drop Multiplier
+
+| Level | Multiplier | Cost |
+|-------|------------|------|
+| 1 | 2× | $1,000,000 |
+| 2 | 3× | $2,000,000 |
+| 3 | 4× | $5,000,000 |
+| 4 | Max | — |
+
+**Effect:** Increases the amount of drops from mobs.
+
+---
+
+## 👥 Member Limit
+
+| Level | Members | Cost |
+|-------|---------|------|
+| 1 | 4 | $100,000 |
+| 2 | 8 | $300,000 |
+| 3 | 16 | $500,000 |
+| 4 | 32 | Max |
+
+**Effect:** Expands how many members can join your island team.
+
+---
+
+## 📏 Island Size
+
+| Level | Size | Cost |
+|-------|------|------|
+| 1 | 100×100 | $30,000 |
+| 2 | 150×150 | $80,000 |
+| 3 | 250×250 | $150,000 |
+| 4 | Max | — |
+
+**Effect:** Expands your island’s protected area.
+
+---
+
+## 🪨 Generator Upgrades
+
+Unlock rarer ores in your cobblestone/stone generator.
+
+| Level | Highlights | Cost |
+|-------|------------|------|
+| 1 | Stone, Diorite, Granite, Iron | $25,000 |
+| 2 | Adds Redstone, Lapis | $75,000 |
+| 3 | Adds Gold, Emerald | $150,000 |
+| 4 | Adds Diamond, higher rare ore chance | $300,000 |
+| 5 | Deepslate ores, high ore chance | $600,000 |
+
+**Effect:** Improves cobblestone generator output with rare ores.
+
+---
+
+## 🚂 Minecart Limit
+
+| Level | Limit | Cost |
+|-------|-------|------|
+| 1 | 4 | $1,000,000 |
+| 2 | 8 | $3,000,000 |
+| 3 | 16 | $9,000,000 |
+| 4 | 32 | Max |
+
+**Effect:** Increases how many minecarts you can place.


### PR DESCRIPTION
## Summary
- add a dedicated Island Upgrades guide covering all upgrade tiers, costs, and effects
- link the new page from the features overview for easier discovery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31c13cfb083328d1010a94a0f0948