### PR TITLE
Update collections guide for current gathering types

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,5 +10,6 @@
   * [☠️ Death & Respawn](features/death-and-respawn.md)
   * [📊 Skills & Stats](features/skills.md)
   * [📊 Stats](features/stats.md)
+* [📦 Collections](collections.md)
 * 🧩 Extras
   * [📝 Patch Notes](extras/patch-notes.md)

--- a/collections.md
+++ b/collections.md
@@ -1,0 +1,69 @@
+# 📦 Collections Guide
+
+Collections track how much of each resource you have gathered across the server. Right now they serve purely as a progress log and friendly competition tool—there are **no unlockable recipes, trades, or stat bonuses yet**. As the economy grows, tiers will begin to award unique crafts and perks, so building progress now keeps you ready for future content drops.
+
+## 🔓 How Collections Work
+
+* **Gather resources:** Mining ore, excavating rare finds, farming crops, ranching animals, foraging logs, and fishing all add toward their respective collections.
+* **Shared progress:** Your island members contribute to the same totals, so work together to push difficult tiers.
+* **Check the menu:** Open the SkyBlock Menu (nether star) → **Collections**, or run `/collections` to view your totals and next milestones.
+* **Tiered milestones:** Each collection still displays the traditional 9–12 tiers. Until rewards arrive, these tiers exist only for tracking purposes.
+
+> 🎯 Reality check: Collections are a long-term system. Even though unlocks are disabled right now, the progress you earn today will instantly count once rewards are enabled in a future update.
+
+## 🧺 Farming Collections
+
+Crops and garden produce each have their own collection bar. Log in regularly to keep them ticking upward—even without rewards, they are a solid benchmark for your island’s agricultural prowess.
+
+| Collection | Current Status |
+| --- | --- |
+| Wheat, Carrot, Potato | Tracks total harvests. Rewards planned for future patches. |
+| Sugar Cane, Nether Wart | Records gathered crops. No recipes available yet. |
+| Mushroom, Cocoa Beans | Progress counts, unlocks pending. |
+| Cactus, Melon, Pumpkin | Collection tiers active for tracking only. |
+
+## 🐄 Ranching Collections
+
+Animals raised on your island contribute to ranching totals. Whether you are collecting meat, leather, milk, or wool, every drop adds progress that will carry over once ranching unlocks arrive.
+
+* **Cows & Mooshrooms** — Milk, leather, and beef tallies record for future dairy tools and armors.
+* **Pigs, Chickens, Sheep** — Store bacon, feathers, eggs, and wool progress for later recipes.
+* **Rabbits** — Track hides and feet now to be ready for upcoming potion and gear unlocks.
+
+## ⛏️ Mining Collections
+
+Mine stone, ores, and gemstones in public zones or on your island to watch these collections climb. While they do not grant equipment yet, they showcase your dedication to gathering.
+
+* **Stone & Cobblestone** — Logs your block-breaking totals.
+* **Coal, Iron, Gold, Emerald** — Measure your time in the mines; rewards coming later.
+* **Diamond, Obsidian** — High-end milestones without recipes for now.
+* **Quartz, Mithril, Gemstones** — Progress toward upcoming late-game crafting lines.
+
+## 🪣 Excavating Collections
+
+Digging with a shovel or spade builds excavating collections that track sand, gravel, clay, and other diggable materials. These tiers are currently placeholders, but early progress will convert into recipes and utility items once released.
+
+| Material | Current Status |
+| --- | --- |
+| Sand & Red Sand | Tracks excavated blocks. Rewards will be announced later. |
+| Gravel & Flint | Collection levels only; expect future tool unlocks. |
+| Clay | Keeps count for upcoming decorative crafts. |
+| Ancient Relics | Special drops still log progress despite rewards being disabled. |
+
+## 🌲 Foraging Collections
+
+Gather logs from the public forests or your island tree farms. Each wood type (Oak, Birch, Spruce, Dark Oak, Acacia, Jungle, and Crimson) has a collection track that currently records totals for future furniture, talisman, and tool unlocks.
+
+## 🎣 Fishing Collections
+
+Fishing collections progress as you reel in catches from ponds, the park, dungeon pools, or lava spots. No fishing recipes or trophy upgrades are available yet, but the data will carry over once those systems are enabled.
+
+## 🛠️ Maximizing Collection Gains
+
+1. **Group play sessions:** Collections only tick while someone is online and gathering, so organize island grind nights.
+2. **Upgrade your tools:** Efficient enchants, reforges, and potions keep manual gathering fast without automation.
+3. **Carry a Sack:** Resource sacks auto-pickup bulk drops so nothing is wasted.
+4. **Farm events:** Seasonal events like Spooky, Winter, or Mining Festivals often double specific collection gains.
+5. **Island layout:** Design efficient crop fields, animal pens, and mining setups to grind manually when needed.
+
+Collections may feel minimalist now, but the progress you earn today ensures you will be first in line when recipes, trades, and perks roll out. Stay diligent, compare stats with friends, and be ready to unlock everything the moment rewards go live!


### PR DESCRIPTION
## Summary
- align the collections overview with the active gathering categories on the server
- add dedicated ranching and excavating sections while removing crafting and combat references
- refresh tips and copy to focus on manual progress tracking until future rewards arrive

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ec9747a1ec8332a80181e3cf508f01