### PR TITLE
Document current collection items

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,5 +10,6 @@
   * [☠️ Death & Respawn](features/death-and-respawn.md)
   * [📊 Skills & Stats](features/skills.md)
   * [📊 Stats](features/stats.md)
+* [📦 Collections](collections.md)
 * 🧩 Extras
   * [📝 Patch Notes](extras/patch-notes.md)

--- a/collections.md
+++ b/collections.md
@@ -1,0 +1,163 @@
+# 📦 Collections Guide
+
+Collections track how much of each resource you have gathered across the server. Right now they serve purely as a progress log and friendly competition tool—there are **no unlockable recipes, trades, or stat bonuses yet**. Building progress now simply keeps you ready for future features once rewards are introduced.
+
+## 🔓 How Collections Work
+
+* **Gather resources:** Mining, excavating, farming, ranching, foraging, fishing, and combat grinding all add toward their respective collections.
+* **Shared progress:** Your island members contribute to the same totals, so work together to push difficult tiers.
+* **Check the menu:** Open the SkyBlock Menu (nether star) → **Collections**, or run `/collections` to view your totals and next milestones.
+* **Tiered milestones:** Each collection still displays the traditional 9–12 tiers. Until rewards arrive, these tiers exist only for tracking purposes.
+
+> 🎯 Reality check: Collections are a long-term system. Even though unlocks are disabled right now, the progress you earn today will instantly count once rewards are enabled in a future update.
+
+### Current Categories
+
+* 🧺 Farming — crops and plant drops
+* 🐄 Ranching — animal drops and animal-crafted items
+* ⛏️ Mining — stone, ore, and underground resources
+* 🪣 Excavating — shovel-gathered blocks
+* 🌲 Foraging — wood types and related materials
+* 🎣 Fishing — catches and aquatic finds
+* 🗡️ Killer — hostile mob drops
+
+## 🧺 Farming Collections
+
+All crops and plant-based drops count here. There are no recipes or item unlocks yet—each entry simply records how much you have harvested.
+
+* `beetroot`
+* `cactus`
+* `carrot`
+* `chorus fruit`
+* `cocoa`
+* `crimson fungus`
+* `flower`
+* `glow berry`
+* `kelp`
+* `melon`
+* `mushroom`
+* `netherwart`
+* `potato`
+* `pumpkin`
+* `seeds`
+* `sugar cane`
+* `sweetberry`
+* `warped fungus`
+* `wheat`
+
+## 🐄 Ranching Collections
+
+Animal products from your barns and pastures populate these bars. Every drop you gather is logged for future use once rewards arrive.
+
+* `beef`
+* `chicken`
+* `egg`
+* `feather`
+* `goathorn`
+* `honeycomb`
+* `leather`
+* `mutton`
+* `pork`
+* `rabbit`
+* `rabbitfoot`
+* `rabbithide`
+* `wool`
+
+## ⛏️ Mining Collections
+
+Ore and stone gathered underground or on your island go into these totals.
+
+* `amethyst`
+* `coal`
+* `copper`
+* `diamond`
+* `emerald`
+* `endstone`
+* `glowstone`
+* `gold`
+* `ice`
+* `iron`
+* `lapis lazuli`
+* `magmablock`
+* `nether quartz`
+* `netherite`
+* `netherrack`
+* `obsidian`
+* `redstone`
+* `stone`
+
+## 🪣 Excavating Collections
+
+Use shovels to gather the materials below and watch the excavating page fill up.
+
+* `dirt`
+* `gravel`
+* `mud`
+* `mycelium`
+* `podzol`
+* `redsand`
+* `sand`
+* `snow`
+* `soulsand`
+* `soulsoil`
+
+## 🌲 Foraging Collections
+
+Chop trees in the public forests or your own farms to move these entries forward.
+
+* `acacia`
+* `bamboo`
+* `birch`
+* `cherry`
+* `crimson`
+* `dark oak`
+* `jungle`
+* `mangrove`
+* `oak`
+* `spruce`
+* `warped`
+
+## 🎣 Fishing Collections
+
+Catch these drops from ponds, rivers, and special fishing locations. Progress is tracked only.
+
+* `cod`
+* `ink sac`
+* `pufferfish`
+* `salmon`
+* `sponge`
+* `tropical fish`
+
+## 🗡️ Killer Collections
+
+Combat drops contribute to the killer category. Every mob drop below is logged even though no perks or trades are enabled yet.
+
+* `blaze rod`
+* `bone`
+* `ender pearl`
+* `ghast tear`
+* `gunpowder`
+* `magmacream`
+* `netherstar`
+* `phantom membrane`
+* `prismarine crystals`
+* `prismarine shard`
+* `sculk catalyst`
+* `sea lantern`
+* `shulker shell`
+* `slimeball`
+* `spider eye`
+* `string`
+* `totem of undying`
+* `wither rose`
+* `wither skeleton skull`
+
+## 🛠️ Maximizing Collection Gains
+
+1. **Group play sessions:** Collections only tick while someone is online and gathering, so organize island grind nights.
+2. **Upgrade your tools:** Efficient enchants, reforges, and potions keep manual gathering fast without automation.
+3. **Carry a Sack:** Resource sacks auto-pickup bulk drops so nothing is wasted.
+4. **Farm events:** Seasonal events like Spooky, Winter, or Mining Festivals often double specific collection gains.
+5. **Island layout:** Design efficient crop fields, animal pens, and mining setups to grind manually when needed.
+
+Collections may feel minimalist now, but the progress you earn today ensures you will be first in line when recipes, trades, and perks roll out. Stay diligent, compare stats with friends, and be ready to unlock everything the moment rewards go live!


### PR DESCRIPTION
## Summary
- list every active collection item for farming, ranching, mining, excavating, foraging, fishing, and killer categories
- add a quick-reference section describing the currently supported collection categories
- reiterate that collections are tracking-only until future rewards launch

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ec9747a1ec8332a80181e3cf508f01